### PR TITLE
Fix typo in laminas-validator package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.com/laminas/laminas-i18n-resources.svg?branch=master)](https://travis-ci.com/laminas/laminas-i18n-resources)
 [![Coverage Status](https://coveralls.io/repos/github/laminas/laminas-i18n-resources/badge.svg?branch=master)](https://coveralls.io/github/laminas/laminas-i18n-resources?branch=master)
 
-This "component" provides translation resources, specifically for `laminas/laminas-validate` and
+This "component" provides translation resources, specifically for `laminas/laminas-validator` and
 `laminas/laminas-captcha`, for use with `laminas/laminas-i18n`'s Translator subcomponent.
 
 - File issues at https://github.com/laminas/laminas-i18n-resources/issues

--- a/docs/book/index.html
+++ b/docs/book/index.html
@@ -2,7 +2,7 @@
   <div class="jumbotron">
     <h1>laminas-i18n-resources</h1>
 
-    <p>laminas-i18n translation resources for laminas-validate and laminas-captcha.</p>
+    <p>laminas-i18n translation resources for laminas-validator and laminas-captcha.</p>
 
     <pre><code class="language-bash">$ composer require laminas/laminas-i18n-resources</code></pre>
   </div>


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes

### Description

Fix typo in referenced package name - `laminas-validate` instead of `laminas/laminas-validator`.